### PR TITLE
Blog: OpenClaw as personal always-on AI assistant

### DIFF
--- a/_posts/2026-02-21-openclaw-personal-ai-assistant.md
+++ b/_posts/2026-02-21-openclaw-personal-ai-assistant.md
@@ -1,0 +1,122 @@
+---
+title: "OpenClaw: My Always-On Personal AI Assistant"
+description: "How I turned OpenClaw into a proactive personal AI that monitors my tasks, sends me Discord updates, and actually gets things done — without me asking twice."
+date: 2026-02-21 09:00
+categories: [ai, productivity]
+tags: ["ai", "openclaw", "productivity", "discord", "automation"]
+---
+
+![OpenClaw Personal Assistant](/assets/img/openclaw-cron.png "OpenClaw: Always-On AI")
+
+---
+
+## OpenClaw: My Always-On Personal AI Assistant
+
+Most AI tools are reactive. You open a chat, you ask something, you get an answer. You close the tab. The AI forgets everything. You start from zero next time.
+
+That's not what I wanted. I wanted an assistant that *actually assists* — one that runs in the background, knows my context, and proactively gets things done. After several weeks of using **OpenClaw**, that's exactly what I have.
+
+Here's how it works.
+
+---
+
+## The Problem with Reactive AI
+
+The gap between "AI chatbot" and "AI assistant" is bigger than most people realize.
+
+A chatbot answers questions. An assistant:
+- Remembers your preferences and history
+- Checks in on things without being told
+- Acts on your behalf — and tells you what it did
+- Escalates when it needs your input
+
+OpenClaw bridges that gap. It's a self-hostable AI agent gateway built around Claude, and once it's running, it genuinely feels less like software and more like a colleague who works while you sleep.
+
+---
+
+## Memory That Persists
+
+The first thing I set up was the memory system. OpenClaw maintains two levels of memory:
+
+**Daily logs** (`memory/YYYY-MM-DD.md`) — raw notes from everything that happened in a session. What was researched, what was done, what was decided.
+
+**Long-term memory** (`MEMORY.md`) — a curated file the agent updates itself over time. It contains my preferences, recurring contexts, credentials locations, workflows — anything worth keeping between restarts.
+
+When a new session starts, the agent reads today's and yesterday's memory files before doing anything else. It's not a perfect episodic memory, but in practice it's surprisingly effective. The agent knows my blog's URL and PR workflow. It knows where my GitHub PAT is stored. It knows which Discord channel to notify me on. I didn't have to repeat myself after the first setup.
+
+---
+
+## Proactive Cron Jobs
+
+The second piece: **scheduled autonomous runs**.
+
+OpenClaw has a built-in cron system. I've set up several recurring jobs:
+
+- **Every hour:** Check `todos.json` for `in-progress` tasks — if something can be done, do it, mark it `done`, and ping me on Discord
+- **Morning heartbeat:** Check weather, scan for news, draft a short briefing
+- **Finance tracker:** Pull current stock and crypto prices, update my portfolio report
+
+These aren't just scheduled messages. They're full agent runs — the AI reads files, makes decisions, executes tasks, and reports back. If a todo requires a blog article, it writes one and opens a pull request. If it can't complete something, it tells me exactly why and what the next step is.
+
+---
+
+## Discord as the Notification Layer
+
+I live in Discord. So naturally, that's where OpenClaw reports.
+
+Every meaningful action gets a Discord notification — with an emoji, a title, and a concrete result. Not "I tried to do X." More like:
+
+> ✅ **Blog Artikel schreiben** — PR geöffnet: https://github.com/d4sw4r/d4sw4r.github.io/pull/42
+
+The rule I set for myself: **no notification without a concrete output**. No vague status updates. If the agent says it's done, there's a link or a file path proving it.
+
+This makes a huge difference. I can glance at Discord and immediately know what happened, what was completed, and what still needs my attention.
+
+---
+
+## The Todos Workflow
+
+My task management is a flat `todos.json` file with four statuses: `backlog`, `in-progress`, `done`, and `cancelled`.
+
+The cron job runs every hour:
+1. Read the file
+2. Filter for `in-progress`
+3. For each task: can I complete it? → Do it, mark `done`, send Discord result
+4. Can't complete it? → Leave `in-progress`, explain blockers
+5. Requires external action (ordering, posting)? → Never mark `done` — I need to confirm
+
+It's a simple loop, but it's surprisingly powerful. Tasks like "write a blog post," "research prices," or "generate a report" just... happen. I add them to the backlog, flip them to `in-progress` when I'm ready, and come back to a Discord notification with the result.
+
+---
+
+## What It Can't Do (Yet)
+
+To be fair: there are limits.
+
+OpenClaw won't send emails or place orders autonomously — and that's intentional. Anything with real-world side effects beyond my own systems requires my confirmation. This isn't a limitation I want to remove; it's a safeguard I set deliberately.
+
+It also can't proactively *discover* what needs doing — it works from explicit tasks. The intelligence is in the execution, not the goal-setting. That's still my job.
+
+---
+
+## The Setup, Briefly
+
+If you want something similar:
+
+1. **Self-host OpenClaw** — runs on any Linux machine, including a small VPS
+2. **Connect it to Discord** — the channel plugin handles outbound notifications
+3. **Write a `todos.json`** — flat file, no database needed
+4. **Set up cron jobs** — the built-in scheduler handles timing and isolated agent runs
+5. **Define memory conventions** — what should persist, what's ephemeral
+
+The whole thing took an afternoon to set up and has been running reliably since. The config is a few YAML files. The "skills" are just natural language instructions in markdown files the agent reads at startup.
+
+---
+
+## Final Thoughts
+
+The shift from reactive to proactive AI feels small until you experience it. Once you have an agent that checks in, completes tasks, and reports back — going back to a simple chatbot feels like a downgrade.
+
+OpenClaw isn't magic. But it's the closest thing I've found to an AI that actually *works for me* rather than waiting to be used.
+
+If you're building something similar or have questions about the setup, feel free to reach out.


### PR DESCRIPTION
New blog post for 2026-02-21.

Covers: persistent memory, proactive cron jobs, Discord notifications, todos workflow, and practical setup tips.

File: `_posts/2026-02-21-openclaw-personal-ai-assistant.md`