### PR TITLE
Add blog post: Agentic AI - The Shift from Chatbots to Autonomous Workers

### DIFF
--- a/_posts/2026-02-25-agentic-ai-autonomous-workers.md
+++ b/_posts/2026-02-25-agentic-ai-autonomous-workers.md
@@ -1,0 +1,137 @@
+---
+title: "Agentic AI: The Shift from Chatbots to Autonomous Workers"
+description: "AI stopped waiting to be asked. In 2026, agentic systems are running entire workflows — and the gap between a chatbot and an autonomous worker is bigger than most people realize."
+date: 2026-02-25 19:00
+categories: [ai, productivity]
+tags: ["ai", "agents", "automation", "llm", "agentic-ai"]
+---
+
+![Agentic AI](/assets/img/openclaw-cron.png "Agentic AI: The Next Phase")
+
+---
+
+## Agentic AI: The Shift from Chatbots to Autonomous Workers
+
+There's a quiet revolution happening in AI right now, and it's not about a new model release.
+
+It's about what AI *does* between conversations.
+
+In 2024, the big story was LLMs — GPT-4, Claude 3, Gemini. In 2025, it was multimodal and reasoning. In 2026, the story is **agency** — AI systems that don't just answer questions, but plan, act, and complete entire workflows on their own.
+
+And honestly? It's the most significant shift yet.
+
+---
+
+## What "Agentic" Actually Means
+
+The word gets thrown around a lot, so let me be specific.
+
+A **chatbot** responds to input. You ask, it answers. It has no memory of yesterday, no awareness of tomorrow, and no ability to do anything in the world beyond generating text.
+
+An **agent** is different. It:
+- Maintains context over time
+- Breaks goals into steps and executes them sequentially
+- Uses tools (web search, APIs, file systems, code execution)
+- Makes decisions mid-task based on what it finds
+- Reports results — not just text, but actual outputs
+
+The key word is *autonomy*. An agent doesn't need you in the loop for every step.
+
+---
+
+## This Is Already Happening at Scale
+
+This isn't a research paper. It's production.
+
+**Walmart** is using agentic AI for payroll processing — a task that used to require human review at every step. The agent handles exceptions, escalates when needed, and runs the loop end-to-end.
+
+**AstraZeneca** is deploying agents in drug research pipelines. Not to replace scientists, but to run experiments, summarize literature, and surface hypotheses faster than any human team could.
+
+These aren't demos. These are live systems processing real data and making real decisions.
+
+---
+
+## The Architecture Behind It
+
+If you're curious how this works under the hood, here's the short version.
+
+Modern agentic systems are built around a **loop**:
+
+```
+Observe → Plan → Act → Observe → Plan → Act → ...
+```
+
+The LLM acts as the "brain" — it interprets the current state and decides what to do next. Tools extend what it can do: search the web, run code, read files, call APIs, write to databases.
+
+What makes 2026 different is the **reliability** of this loop. Earlier attempts at agents were brittle — one bad step and the whole chain broke. Current models are significantly better at self-correction, recognizing when a plan isn't working, and adapting mid-task.
+
+The other piece: **memory**. Agents need to carry context across sessions. This is still a partially solved problem, but the common patterns — external memory stores, structured context files, retrieval-augmented generation — are mature enough to build production systems on.
+
+---
+
+## Small Models, Focused Agents
+
+One trend I find particularly interesting: **Small Language Models (SLMs)** are getting serious attention for agentic workloads.
+
+The idea is simple: you don't need a frontier model for every step of a workflow. A focused 3B-parameter model fine-tuned on a specific domain can outperform a general 70B model on that task — at a fraction of the cost and latency.
+
+Gartner's projection is that by 2027, SLMs will be deployed three times more than large models for specialized tasks. That tracks with what I'm seeing: more "model routing" architectures where a cheap, fast model handles routine steps and escalates only when it needs heavy reasoning.
+
+This changes the economics significantly. Agentic systems start to look viable at a much smaller scale.
+
+---
+
+## The Part Nobody Talks About
+
+Here's what I think is underrated in all the agentic AI hype: **the organizational shift**.
+
+When AI can run entire workflows autonomously, the bottleneck moves. It's no longer "can the AI do this?" It's "have we designed the right process for the AI to follow?"
+
+That's a fundamentally different problem. It requires thinking about:
+- Where human oversight is genuinely needed vs. where it's just habit
+- How to structure tasks so they're legible to an automated system
+- What "done" means when the agent decides it
+
+Companies that figure this out first — that design their workflows *for* agentic execution — will have a structural advantage. Not because the AI is smarter, but because they've removed the human bottlenecks from the parts that don't need them.
+
+---
+
+## Where It Breaks
+
+To be fair: agentic AI fails in predictable ways.
+
+**Compounding errors.** One wrong assumption early in a chain can propagate through every subsequent step. The agent doesn't know it's wrong. You get a confident, well-structured, completely incorrect result.
+
+**Tool misuse.** Give an agent access to tools it doesn't fully understand and it will occasionally do something unexpected. Not maliciously — just incorrectly.
+
+**Goal misalignment.** The agent optimizes for what you specified, not what you meant. If your specification is slightly off, the result will be too.
+
+None of these are unsolvable. But they require design — careful task decomposition, explicit checkpoints, human review at the right moments. "Autonomous" doesn't mean "unmonitored."
+
+---
+
+## What This Means for Developers
+
+If you build software, this is the wave to catch.
+
+Not because you need to integrate GPT-4o into your app for the sake of it. But because the **agent-native architecture** is a genuinely new primitive:
+
+- Apps that act on your behalf, not just surface information
+- Workflows that adapt based on what they find, not just what you configured
+- Systems that report outcomes, not just process requests
+
+The developers who understand how to build reliable agent loops — with proper memory, tool use, error handling, and human-in-the-loop design — are going to be in high demand. That skillset is new enough that most people don't have it yet.
+
+---
+
+## Final Thoughts
+
+The chatbot era is ending. Not because chatbots aren't useful, but because we've built something more capable on top of them.
+
+Agentic AI isn't a feature. It's a different category of software — one that acts, not just responds. And 2026 is the year it goes from "interesting demo" to "running in production at companies you've heard of."
+
+Worth paying attention to. Worth building for.
+
+---
+
+*More on my experiments with agentic AI: the [OpenClaw series](/tags/openclaw/).*


### PR DESCRIPTION
New blog post about the agentic AI trend — from chatbots to autonomous workers. Covers the architecture, real-world deployments (Walmart, AstraZeneca), SLMs, failure modes, and what this means for developers.

Topic picked for relevance to current Feb 2026 trends.