### PR TITLE
Add post: FluxCD vs ArgoCD — The GitOps Showdown

### DIFF
--- a/_posts/2026-03-02-fluxcd-vs-argocd.md
+++ b/_posts/2026-03-02-fluxcd-vs-argocd.md
@@ -1,0 +1,85 @@
+---
+layout: post
+title: "FluxCD vs ArgoCD: The GitOps Showdown You Need to Settle Before Your Next Cluster"
+date: 2026-03-02
+categories: [DevOps, GitOps]
+tags: ["fluxcd", "argocd", "gitops", "kubernetes", "devops"]
+---
+
+If you've spent more than five minutes in the Kubernetes ecosystem, you've encountered the question: **FluxCD or ArgoCD?** Both are CNCF-graduated GitOps tools. Both reconcile your cluster state with a Git repository. Both will make your Ops team sleep better at night — in theory. But they're fundamentally different in philosophy, and picking the wrong one will cost you.
+
+I've run both in production. Here's the unfiltered take.
+
+## The Core Philosophy Divide
+
+ArgoCD was built by Intuit and thinks like a product. It gives you a beautiful web UI, a centralized control plane, real-time sync status, visual diffs, and rollback at a click. It wants to be the cockpit from which you manage your entire fleet.
+
+FluxCD was born at Weaveworks and thinks like a Kubernetes controller. It's a collection of modular operators — source-controller, helm-controller, kustomize-controller — each doing exactly one thing, each running natively inside your cluster, reconciling state the way Kubernetes itself does. No extra layer. No external opinions. Pure GitOps discipline.
+
+This isn't just a UX difference. It's a worldview difference.
+
+## What ArgoCD Gets Right
+
+**The UI is genuinely great.** If you're managing multiple environments, having visual diffs between your Git state and live cluster state is worth real money in debugging time. ArgoCD's application graph showing pod health, sync status, and resource relationships in one view is legitimately useful — not just pretty.
+
+**Multi-cluster management is native.** One ArgoCD instance can manage dozens of downstream clusters with built-in RBAC, SSO via OIDC/LDAP, and `ApplicationSets` that template deployments across environments. For platform teams managing fleets of clusters for different tenants or regions, this centralized model reduces operational complexity significantly.
+
+**Onboarding is fast.** A developer who's never touched GitOps can be productive in ArgoCD within hours. The learning curve is gentle because the UI abstracts away a lot of the kubectl-and-YAML complexity. For organizations trying to democratize deployment access, this matters.
+
+**Argo Rollouts integration.** If you want canary deployments, blue/green strategies, and progressive delivery with automated analysis, Argo's ecosystem is ahead. Rollouts integrates tightly with ArgoCD and the experience is polished.
+
+## What FluxCD Gets Right
+
+**Kubernetes-native to the bone.** FluxCD adds no external control plane. Every Flux component is a Kubernetes controller. Your GitOps config lives in CRDs. Your RBAC is Kubernetes RBAC. There's no separate identity store to manage, no extra API server to secure. If you believe "the Kubernetes API is the truth," Flux is your tool.
+
+**Strict drift enforcement.** ArgoCD can be configured to auto-sync, but it can also be set to manual sync and let drift accumulate silently. Flux, by default, continuously reconciles and discards any local changes. Git is the source of truth, full stop, no exceptions. For platform engineers who are serious about GitOps purity, this default behavior is the right one.
+
+**Better scalability for large clusters.** Because each Flux controller is independent and scoped to its own reconciliation loop, there's no centralized bottleneck. In large environments (think 1000+ workloads), Flux's distributed architecture handles scale better. ArgoCD's centralized model works well too, but it requires more careful capacity planning.
+
+**Image automation.** Flux has a built-in image reflector and automation controller that can automatically update image tags in Git when a new image is pushed. It's a small feature with big impact for teams doing continuous deployment — and ArgoCD doesn't have a native equivalent.
+
+**Bootstrap is clean.** `flux bootstrap github` sets up your entire GitOps config in one command. It's elegant and reproducible in a way that feels right.
+
+## The Elephant in the Room: Weaveworks
+
+In February 2024, Weaveworks — the company that created FluxCD — shut down. CEO Alexis Richardson announced the closure after the company raised over $61M but couldn't reach sustainable growth. For a brief moment, the Flux community panicked.
+
+Here's the reality in 2026: **Flux is fine.** It's a CNCF graduated project (since 2022), independent of Weaveworks. Core maintainers moved to other companies and continued contributing. Large enterprises like Deutsche Telekom kept running it without disruption. The project is alive.
+
+But the optics matter. If you're in a risk-averse enterprise that needs commercial backing and a vendor you can call, ArgoCD has a healthier support ecosystem right now. Codefresh, Red Hat (via OpenShift GitOps), and Akuity all back ArgoCD commercially. Flux's commercial support story is thinner.
+
+For open-source-first teams who trust CNCF governance? Flux is perfectly viable.
+
+## The Verdict: Stop Looking for the Universal Answer
+
+Here's the uncomfortable truth: there is no objectively "better" tool. There's only **better for your context**.
+
+**Choose ArgoCD if:**
+- Your team includes developers who need a visual interface to understand deployments
+- You're managing multi-cluster fleets and want a centralized control plane
+- You want commercial support options (Akuity, Codefresh, OpenShift GitOps)
+- You need progressive delivery (canary, blue/green) via Argo Rollouts
+- You're onboarding teams new to GitOps
+
+**Choose FluxCD if:**
+- You have platform engineers who think in Kubernetes controllers and CRDs
+- You want strict GitOps — no exceptions, no manual overrides, Git is truth
+- You're running large-scale or edge deployments where resource efficiency matters
+- You want image automation out of the box
+- You prefer no external control plane — just Kubernetes, all the way down
+
+**My personal take:** For greenfield platform engineering work at scale, I reach for Flux. The purity of "everything is a Kubernetes controller" aligns with how modern platform teams think, and the operational simplicity of not having an extra system to manage pays off over time.
+
+For teams with mixed DevOps maturity — where developers actually own deployments and need a UI to be productive — ArgoCD wins on pragmatism.
+
+The wrong choice isn't picking one over the other. The wrong choice is picking one before you've honestly assessed which category your team falls into.
+
+## One More Thing
+
+Both tools support Helm and Kustomize. Both support multi-tenancy. Both work fine for 90% of use cases. If you're spending weeks agonizing over this decision, you're procrastinating. Pick one. Run it for six months. You'll know if it's wrong.
+
+And if you end up running both? That's also a valid architecture. Some teams use Flux for infrastructure and ArgoCD for application deployments. Weird? A little. Battle-tested? Absolutely.
+
+---
+
+*Running either tool in production? Drop a comment — especially if you've migrated from one to the other.*


### PR DESCRIPTION
## New Blog Post

**FluxCD vs ArgoCD: The GitOps Showdown You Need to Settle Before Your Next Cluster**

A ~1100 word, opinionated deep-dive covering:
- Core philosophy differences (product vs. controller mindset)
- What ArgoCD gets right (UI, multi-cluster, Rollouts)
- What FluxCD gets right (K8s-native, strict drift, image automation)
- The Weaveworks shutdown context and what it means in 2026
- Clear decision framework for picking the right tool

Researched and written by Hugo (blog-agent).

> Note: Cover image skipped — no `OPENAI_API_KEY` available in the environment.